### PR TITLE
Prevent silent chat fallback for strategy mutations

### DIFF
--- a/Core/MultiBotEngine.lua
+++ b/Core/MultiBotEngine.lua
@@ -529,9 +529,7 @@ end
 local function _mbWarnStrategyMutationBlocked(commandScope, target, reason)
 	local subject = _mbStrategySubject(commandScope, target)
 	local detail = tostring(reason or "STRATEGY_REJECTED")
-	local message = "|cffff4444[MultiBot]|r " .. subject
-		.. " : echec de la commande de strategie (" .. detail
-		.. "). Aucun fallback chat n'a ete envoye."
+	local message = string.format(MultiBot.L("strategy.warning.blocked"), subject, detail)
 
 	if(DEFAULT_CHAT_FRAME and DEFAULT_CHAT_FRAME.AddMessage) then
 		DEFAULT_CHAT_FRAME:AddMessage(message)
@@ -540,7 +538,7 @@ local function _mbWarnStrategyMutationBlocked(commandScope, target, reason)
 	end
 
 	if(UIErrorsFrame and UIErrorsFrame.AddMessage) then
-		UIErrorsFrame:AddMessage("MultiBot : commande de strategie refusee - " .. subject, 1, 0.25, 0.25, 1)
+		UIErrorsFrame:AddMessage(string.format(MultiBot.L("strategy.warning.refused"), subject), 1, 0.25, 0.25, 1)
 	end
 end
 

--- a/Core/MultiBotEngine.lua
+++ b/Core/MultiBotEngine.lua
@@ -489,6 +489,12 @@ local function _mbParseStrategyMutation(action)
 	return scope, changes
 end
 
+-- MB_P1_STRATEGY_NO_SILENT_CHAT_FALLBACK_V1_START
+local MB_STRATEGY_ROUTE_NOT_STRATEGY = "NOT_STRATEGY"
+local MB_STRATEGY_ROUTE_BRIDGE = "BRIDGE"
+local MB_STRATEGY_ROUTE_LEGACY = "LEGACY"
+local MB_STRATEGY_ROUTE_BLOCKED = "BLOCKED"
+
 local function _mbCanUseBridgeStrategyMutation()
 	return MultiBot.bridge
 		and MultiBot.bridge.connected == true
@@ -497,38 +503,117 @@ local function _mbCanUseBridgeStrategyMutation()
 		and type(MultiBot.Comm.RunStrategyCommand) == "function"
 end
 
-local function _mbRunBridgeStrategyMutation(action, commandScope, target)
-	if(not _mbCanUseBridgeStrategyMutation()) then return false end
+local function _mbStrategyBridgeUnavailableReason()
+	if(not MultiBot.bridge) then return "STRATEGY_BRIDGE_UNAVAILABLE" end
+	if(MultiBot.bridge.connected ~= true) then return "STRATEGY_NOT_CONNECTED" end
+	if(MultiBot.bridge.strategyMutationCapable ~= true) then return "STRATEGY_CAPABILITY_UNAVAILABLE" end
+	if(not MultiBot.Comm or type(MultiBot.Comm.RunStrategyCommand) ~= "function") then
+		return "STRATEGY_CLIENT_UNAVAILABLE"
+	end
+	return "STRATEGY_UNAVAILABLE"
+end
 
-	local mutationScope, changes = _mbParseStrategyMutation(action)
-	if(not mutationScope) then return false end
+local function _mbStrategyLastError(fallback)
+	local reason = MultiBot.bridge and MultiBot.bridge.lastError
+	if(type(reason) == "string" and reason ~= "") then return reason end
+	return fallback or "STRATEGY_REJECTED"
+end
+
+local function _mbStrategySubject(commandScope, target)
+	if(type(target) == "string" and target ~= "") then return target end
+	commandScope = string.lower(commandScope or "group")
+	if(commandScope == "") then commandScope = "group" end
+	return commandScope
+end
+
+local function _mbWarnStrategyMutationBlocked(commandScope, target, reason)
+	local subject = _mbStrategySubject(commandScope, target)
+	local detail = tostring(reason or "STRATEGY_REJECTED")
+	local message = "|cffff4444[MultiBot]|r " .. subject
+		.. " : echec de la commande de strategie (" .. detail
+		.. "). Aucun fallback chat n'a ete envoye."
+
+	if(DEFAULT_CHAT_FRAME and DEFAULT_CHAT_FRAME.AddMessage) then
+		DEFAULT_CHAT_FRAME:AddMessage(message)
+	elseif(type(print) == "function") then
+		print(message)
+	end
+
+	if(UIErrorsFrame and UIErrorsFrame.AddMessage) then
+		UIErrorsFrame:AddMessage("MultiBot : commande de strategie refusee - " .. subject, 1, 0.25, 0.25, 1)
+	end
+end
+
+local function _mbRefreshStrategyState(commandScope, target)
+	if(not MultiBot.bridge or MultiBot.bridge.connected ~= true or not MultiBot.Comm) then return end
 
 	commandScope = string.upper(commandScope or "BOT")
 	target = target or ""
-	local stateScope = mutationScope == "nc" and "N" or "C"
 
-	local token = MultiBot.Comm.RunStrategyCommand(commandScope, target, stateScope, changes, function(result)
-		if(type(result) ~= "table") then return end
-		if(not MultiBot.bridge or MultiBot.bridge.connected ~= true) then return end
-
-		if(commandScope == "BOT") then
-			if(MultiBot.Comm and MultiBot.Comm.RequestState) then
-				MultiBot.Comm.RequestState(target)
-			end
-		elseif(MultiBot.Comm and MultiBot.Comm.RequestStates) then
-			MultiBot.Comm.RequestStates()
+	if(commandScope == "BOT") then
+		if(target ~= "" and type(MultiBot.Comm.RequestState) == "function") then
+			MultiBot.Comm.RequestState(target)
 		end
+	elseif(type(MultiBot.Comm.RequestStates) == "function") then
+		MultiBot.Comm.RequestStates()
+	end
+end
+
+local function _mbRouteStrategyMutation(action, commandScope, target)
+	local mutationScope, changes = _mbParseStrategyMutation(action)
+	if(not mutationScope) then return MB_STRATEGY_ROUTE_NOT_STRATEGY end
+
+	commandScope = string.upper(commandScope or "BOT")
+	target = target or ""
+
+	if(not _mbCanUseBridgeStrategyMutation()) then
+		if(MultiBot.allowLegacyChatFallback == true) then
+			return MB_STRATEGY_ROUTE_LEGACY
+		end
+
+		_mbWarnStrategyMutationBlocked(commandScope, target, _mbStrategyBridgeUnavailableReason())
+		_mbRefreshStrategyState(commandScope, target)
+		return MB_STRATEGY_ROUTE_BLOCKED
+	end
+
+	local stateScope = mutationScope == "nc" and "N" or "C"
+	local token = MultiBot.Comm.RunStrategyCommand(commandScope, target, stateScope, changes, function(result)
+		if(type(result) ~= "table") then
+			_mbWarnStrategyMutationBlocked(commandScope, target, "STRATEGY_INVALID_RESULT")
+			_mbRefreshStrategyState(commandScope, target)
+			return
+		end
+
+		if(result.status ~= "ok") then
+			local reason = result.reason
+			if(type(reason) ~= "string" or reason == "") then
+				reason = result.status or "STRATEGY_REJECTED"
+			end
+			_mbWarnStrategyMutationBlocked(commandScope, target, reason)
+		end
+
+		_mbRefreshStrategyState(commandScope, target)
 	end)
 
-	return token ~= false and token ~= nil
+	if(token ~= false and token ~= nil) then
+		return MB_STRATEGY_ROUTE_BRIDGE
+	end
+
+	_mbWarnStrategyMutationBlocked(commandScope, target, _mbStrategyLastError("STRATEGY_SEND_FAILED"))
+	_mbRefreshStrategyState(commandScope, target)
+	return MB_STRATEGY_ROUTE_BLOCKED
 end
 
 MultiBot.ActionToTarget = function(pAction, oTarget)
 	local tName = MultiBot.IF(oTarget == nil, UnitName("target"), oTarget)
 
 	if(tName ~= nil and tName ~= "Unknown Entity") then
-		if(_mbRunBridgeStrategyMutation(pAction, "BOT", tName)) then
+		local route = _mbRouteStrategyMutation(pAction, "BOT", tName)
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
 			return true, "bridge"
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			return false, "blocked"
 		end
 
 		SendChatMessage(pAction, "WHISPER", nil, tName)
@@ -547,16 +632,24 @@ MultiBot.ActionToTargetOrGroup = function(pAction)
 	end
 
 	if(GetNumRaidMembers() > 5) then
-		if(_mbRunBridgeStrategyMutation(pAction, "RAID", "")) then
+		local route = _mbRouteStrategyMutation(pAction, "RAID", "")
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
 			return true
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			return false
 		end
 		SendChatMessage(pAction, "RAID")
 		return true
 	end
 
 	if(GetNumPartyMembers() > 0) then
-		if(_mbRunBridgeStrategyMutation(pAction, "PARTY", "")) then
+		local route = _mbRouteStrategyMutation(pAction, "PARTY", "")
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
 			return true
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			return false
 		end
 		SendChatMessage(pAction, "PARTY")
 		return true
@@ -568,16 +661,24 @@ end
 
 MultiBot.ActionToGroup = function(pAction)
 	if(GetNumRaidMembers() > 5) then
-		if(_mbRunBridgeStrategyMutation(pAction, "RAID", "")) then
+		local route = _mbRouteStrategyMutation(pAction, "RAID", "")
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
 			return true
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			return false
 		end
 		SendChatMessage(pAction, "RAID")
 		return true
 	end
 
 	if(GetNumPartyMembers() > 0) then
-		if(_mbRunBridgeStrategyMutation(pAction, "PARTY", "")) then
+		local route = _mbRouteStrategyMutation(pAction, "PARTY", "")
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
 			return true
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			return false
 		end
 		SendChatMessage(pAction, "PARTY")
 		return true
@@ -586,6 +687,7 @@ MultiBot.ActionToGroup = function(pAction)
 	SendChatMessage(MultiBot.L("info.group"), "SAY")
 	return false
 end
+-- MB_P1_STRATEGY_NO_SILENT_CHAT_FALLBACK_V1_END
 
 MultiBot.SelectToTarget = function(pParent, pIndex, pTexture, pAction, oTarget)
 	if(MultiBot.ActionToTarget(pAction, oTarget)) then
@@ -925,14 +1027,30 @@ MultiBot.OnOffActionToTarget = function(pButton, pOn, pOff, pTarget)
 	local action = wasEnabled and pOff or pOn
 	local mutationScope = _mbParseStrategyMutation(action)
 
-	if(mutationScope and _mbRunBridgeStrategyMutation(action, "BOT", pTarget)) then
-		-- Conserve la sémantique historique du retour pour tous les appelants co/nc.
-		-- L'état visuel définitif reste reconstruit depuis l'ACK puis STATE.
-		return not wasEnabled
-	end
+	if(mutationScope) then
+		local route = _mbRouteStrategyMutation(action, "BOT", pTarget)
+		if(route == MB_STRATEGY_ROUTE_BRIDGE) then
+			-- L'etat visuel definitif reste reconstruit depuis l'ACK puis STATE.
+			return not wasEnabled
+		end
+		if(route == MB_STRATEGY_ROUTE_BLOCKED) then
+			-- Aucun changement optimiste si le bridge refuse ou ne peut pas envoyer.
+			return wasEnabled
+		end
 
-	local unitButton = _mbGetStrategyUnitButton(pTarget)
-	if(mutationScope and unitButton) then unitButton.waitFor = string.upper(mutationScope) end
+		local unitButton = _mbGetStrategyUnitButton(pTarget)
+		if(unitButton) then unitButton.waitFor = string.upper(mutationScope) end
+
+		-- Seul le mode legacy explicitement autorise atteint ce transport chat.
+		SendChatMessage(action, "WHISPER", nil, pTarget)
+		if(wasEnabled) then
+			pButton.setDisable()
+			return false
+		else
+			pButton.setEnable()
+			return true
+		end
+	end
 
 	if(wasEnabled) then
 		MultiBot.ActionToTarget(pOff, pTarget)

--- a/Locales/MultiBotAceLocale-deDE.lua
+++ b/Locales/MultiBotAceLocale-deDE.lua
@@ -1034,6 +1034,8 @@ local deDEValues = {
   ["formation.name.shield"] = "Schild",
   ["formation.name.far"] = "Entfernt",
   ["formation.name.unknown"] = "Unbekannt",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: Strategiebefehl fehlgeschlagen (%s). Es wurde kein Fallback über den Chat gesendet.",
+  ["strategy.warning.refused"] = "MultiBot: Strategiebefehl abgelehnt - %s",
 }
 
 register("deDE", deDEValues)

--- a/Locales/MultiBotAceLocale-enGB.lua
+++ b/Locales/MultiBotAceLocale-enGB.lua
@@ -1037,6 +1037,8 @@ local enGBValues = {
   ["formation.name.shield"] = "Shield",
   ["formation.name.far"] = "Far",
   ["formation.name.unknown"] = "Unknown",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: strategy command failed (%s). No chat fallback was sent.",
+  ["strategy.warning.refused"] = "MultiBot: strategy command refused - %s",
 }
 
 register("enGB", enGBValues)

--- a/Locales/MultiBotAceLocale-enUS.lua
+++ b/Locales/MultiBotAceLocale-enUS.lua
@@ -1037,6 +1037,8 @@ local enUSValues = {
   ["formation.name.shield"] = "Shield",
   ["formation.name.far"] = "Far",
   ["formation.name.unknown"] = "Unknown",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: strategy command failed (%s). No chat fallback was sent.",
+  ["strategy.warning.refused"] = "MultiBot: strategy command refused - %s",
 }
 
 register("enUS", enUSValues, true)

--- a/Locales/MultiBotAceLocale-esES.lua
+++ b/Locales/MultiBotAceLocale-esES.lua
@@ -1035,6 +1035,8 @@ local esESValues = {
   ["formation.name.shield"] = "Escudo",
   ["formation.name.far"] = "Lejana",
   ["formation.name.unknown"] = "Desconocida",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: fallo del comando de estrategia (%s). No se envió ningún fallback por chat.",
+  ["strategy.warning.refused"] = "MultiBot: comando de estrategia rechazado - %s",
 }
 
 register("esES", esESValues)

--- a/Locales/MultiBotAceLocale-frFR.lua
+++ b/Locales/MultiBotAceLocale-frFR.lua
@@ -1034,6 +1034,8 @@ local frFRValues = {
   ["formation.name.shield"] = "Bouclier",
   ["formation.name.far"] = "Éloignée",
   ["formation.name.unknown"] = "Inconnue",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s : échec de la commande de stratégie (%s). Aucun fallback chat n'a été envoyé.",
+  ["strategy.warning.refused"] = "MultiBot : commande de stratégie refusée - %s",
 }
 
 register("frFR", frFRValues)

--- a/Locales/MultiBotAceLocale-koKR.lua
+++ b/Locales/MultiBotAceLocale-koKR.lua
@@ -1026,6 +1026,8 @@ local koKRValues = {
   ["formation.name.shield"] = "방패",
   ["formation.name.far"] = "원거리",
   ["formation.name.unknown"] = "알 수 없음",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: 전략 명령에 실패했습니다 (%s). 채팅 대체 전송을 사용하지 않았습니다.",
+  ["strategy.warning.refused"] = "MultiBot: 전략 명령이 거부되었습니다 - %s",
 }
 
 register("koKR", koKRValues)

--- a/Locales/MultiBotAceLocale-ruRU.lua
+++ b/Locales/MultiBotAceLocale-ruRU.lua
@@ -1035,6 +1035,8 @@ local ruRUValues = {
   ["formation.name.shield"] = "Щит",
   ["formation.name.far"] = "Дальнее",
   ["formation.name.unknown"] = "Неизвестно",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s: команда стратегии не выполнена (%s). Резервная отправка через чат не выполнялась.",
+  ["strategy.warning.refused"] = "MultiBot: команда стратегии отклонена - %s",
 }
 
 register("ruRU", ruRUValues)

--- a/Locales/MultiBotAceLocale-zhCN.lua
+++ b/Locales/MultiBotAceLocale-zhCN.lua
@@ -1035,6 +1035,8 @@ local zhCNValues = {
   ["formation.name.shield"] = "盾牌",
   ["formation.name.far"] = "远距离",
   ["formation.name.unknown"] = "未知",
+  ["strategy.warning.blocked"] = "|cffff4444[MultiBot]|r %s：策略命令失败（%s）。未通过聊天备用通道发送。",
+  ["strategy.warning.refused"] = "MultiBot：策略命令被拒绝 - %s",
 }
 
 register("zhCN", zhCNValues)

--- a/Strategies/MultiBotShaman.lua
+++ b/Strategies/MultiBotShaman.lua
@@ -192,7 +192,8 @@ MultiBot.addShaman = function(pFrame, pCombat, pNormal)
 		end
 	end
 
-	local function dispatchShamanPlaybookCommands(target, commands, bridgeSync, sequenceKey, sequence)
+-- MB_P1A_SHAMAN_PLAYBOOK_BLOCKED_STATE_V1_START
+	local function dispatchShamanPlaybookCommands(target, commands, bridgeSync, sequenceKey, sequence, onAccepted)
 		local function sendCommand(index)
 			if(not isShamanPlaybookSequenceCurrent(sequenceKey, sequence)) then return end
 
@@ -205,13 +206,16 @@ MultiBot.addShaman = function(pFrame, pCombat, pNormal)
 					sendCommand(index + 1)
 				end)
 			else
+				if(type(onAccepted) == "function" and isShamanPlaybookSequenceCurrent(sequenceKey, sequence)) then
+					onAccepted()
+				end
 				requestShamanCombatState(target, bridgeSync, sequenceKey, sequence)
 			end
 		end
 
 		sendCommand(1)
 	end
-
+-- MB_P1A_SHAMAN_PLAYBOOK_BLOCKED_STATE_V1_END
 	local function selectExclusiveShamanSpec(pButton, specKey, pOtherOne, pOtherTwo)
 		local defaults = shamanSpecDefaults[specKey]
 		local target = pButton.getName()
@@ -230,17 +234,16 @@ MultiBot.addShaman = function(pFrame, pCombat, pNormal)
 
 		local sequenceKey, sequence = beginShamanPlaybookSequence(target)
 
-		-- The visible Playbook state and QuickShaman defaults are updated on the
-		-- first click. The delayed real-state refresh may only confirm this state;
-		-- it must not race the mutation commands and restore the previous spec.
-		pButton.setEnable()
-		pButton.getButton(pOtherOne).setDisable()
-		pButton.getButton(pOtherTwo).setDisable()
-		applyQuickShamanSpecDefaults(target, specKey)
-
-		dispatchShamanPlaybookCommands(target, commands, bridgeSync, sequenceKey, sequence)
-	end
-	-- HOTFIX_MULTIBOT_SHAMAN_PLAYBOOK_SYNC_V2E2C_END --
+		-- Commit the visible Playbook state and Quick Shaman persisted defaults only
+		-- after every mutation in this sequence has been accepted for delivery.
+		dispatchShamanPlaybookCommands(target, commands, bridgeSync, sequenceKey, sequence, function()
+			if(not isShamanPlaybookSequenceCurrent(sequenceKey, sequence)) then return end
+			pButton.setEnable()
+			pButton.getButton(pOtherOne).setDisable()
+			pButton.getButton(pOtherTwo).setDisable()
+			applyQuickShamanSpecDefaults(target, specKey)
+		end)
+	end	-- HOTFIX_MULTIBOT_SHAMAN_PLAYBOOK_SYNC_V2E2C_END --
 
 	playbookFrame.addButton(
 		"Aoe", 0, 0, "spell_nature_lightningoverload",

--- a/UI/MultiBotLeftCoreUI.lua
+++ b/UI/MultiBotLeftCoreUI.lua
@@ -6,16 +6,29 @@ local MODE_BUTTON_ICON = "Interface\\AddOns\\MultiBot\\Icons\\mode_passive.blp"
 local MODE_FRAME_X = -172
 local MODE_FRAME_Y = 34
 
-local function bindModeToggleAction(modeButton, enableCommand, disableCommand)
-    modeButton.setEnable().doLeft = function(button)
-        if MultiBot.OnOffSwitch(button) then
-            MultiBot.ActionToGroup(enableCommand)
-        else
-            MultiBot.ActionToGroup(disableCommand)
-        end
+-- MB_P1A_MODE_BLOCKED_STATE_V1_START
+local function dispatchModeToggleAction(button, enableCommand, disableCommand)
+    local wasEnabled = button.state == true
+    local command = wasEnabled and disableCommand or enableCommand
+
+    if not MultiBot.ActionToGroup(command) then
+        return false
     end
+
+    if wasEnabled then
+        button.setDisable()
+    else
+        button.setEnable()
+    end
+    return true
 end
 
+local function bindModeToggleAction(modeButton, enableCommand, disableCommand)
+    modeButton.setEnable().doLeft = function(button)
+        dispatchModeToggleAction(button, enableCommand, disableCommand)
+    end
+end
+-- MB_P1A_MODE_BLOCKED_STATE_V1_END
 local function createModeUI(tLeft)
     local modeButton = tLeft.addButton(MODE_BUTTON_NAME, -170, 0, MODE_BUTTON_ICON, MultiBot.L("tips.mode.master")).setDisable()
 
@@ -24,13 +37,8 @@ local function createModeUI(tLeft)
     end
 
     modeButton.doLeft = function(button)
-        if MultiBot.OnOffSwitch(button) then
-            MultiBot.ActionToGroup("co +passive,?")
-        else
-            MultiBot.ActionToGroup("co -passive,?")
-        end
+        dispatchModeToggleAction(button, "co +passive,?", "co -passive,?")
     end
-
     local modeFrame = tLeft.addFrame(MODE_FRAME_NAME, MODE_FRAME_X, MODE_FRAME_Y)
     modeFrame:Hide()
 

--- a/UI/MultiBotShamanQuickFrame.lua
+++ b/UI/MultiBotShamanQuickFrame.lua
@@ -706,6 +706,7 @@ function ShamanQuick:ApplyPersistedChoice(row, elementKey, iconPath)
     end
 end
 
+-- MB_P1A_SHAMAN_QUICK_BLOCKED_STATE_V1_START
 function ShamanQuick:SelectTotem(row, elementKey, button, definition)
     if not row or not elementKey or not button or not definition then
         return
@@ -719,19 +720,21 @@ function ShamanQuick:SelectTotem(row, elementKey, button, definition)
     local isSameSelection = currentButton == button or currentIcon == button.__mbIcon
 
     if isSameSelection then
-        MultiBot.ActionToTarget("co -" .. definition.spell .. ",?", row.owner)
+        if not MultiBot.ActionToTarget("co -" .. definition.spell .. ",?", row.owner) then
+            return
+        end
         self:ClearTotemSelection(row, elementKey)
         return
     end
 
+    local command = "co +" .. definition.spell .. ",?"
     if currentButton and currentButton ~= button and currentButton.__mbSpell then
-        MultiBot.ActionToTarget("co -" .. currentButton.__mbSpell .. ",?", row.owner)
-        if currentButton.SetButtonSelected then
-            currentButton:SetButtonSelected(false)
-        end
+        command = "co -" .. currentButton.__mbSpell .. ",+" .. definition.spell .. ",?"
     end
 
-    MultiBot.ActionToTarget("co +" .. definition.spell .. ",?", row.owner)
+    if not MultiBot.ActionToTarget(command, row.owner) then
+        return
+    end
 
     row.selectedIcons[elementKey] = button.__mbIcon
     self:SetSelectedTotemButton(row, elementKey, button)
@@ -741,7 +744,7 @@ function ShamanQuick:SelectTotem(row, elementKey, button, definition)
         MultiBot.SetShamanTotemChoice(row.owner, elementKey, button.__mbIcon)
     end
 end
-
+-- MB_P1A_SHAMAN_QUICK_BLOCKED_STATE_V1_END
 function ShamanQuick:CreateTotemButton(row, elementDefinition, groupFrame, spellDefinition, index)
     local button = createIconButton(groupFrame, string.format("MultiBotShamanTotem_%s_%s_%d", sanitizeName(row.owner), elementDefinition.key, index), spellDefinition.icon, MultiBot.L(spellDefinition.tip), BUTTON_SIZE)
     button:SetPoint("TOPLEFT", (index - 1) * (BUTTON_SIZE + BUTTON_GAP), 0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bridge-first routing for strategy actions with delivery status and availability diagnostics.
  - Added optional legacy chat fallback when bridge delivery is unavailable.
- **Bug Fixes**
  - Prevented target, group, and raid/party actions from sending chat when delivery is blocked.
  - Ensured buttons, mode toggles, and totem selections update only after successful command delivery.
  - Improved error reporting and state refresh behavior.
  - Prevented incomplete Shaman command sequences from saving settings or changing visual state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->