### PR TITLE
Update MultiBotEvery.lua

### DIFF
--- a/Core/MultiBotEvery.lua
+++ b/Core/MultiBotEvery.lua
@@ -268,7 +268,7 @@ MultiBot.addEvery = function(pFrame, pCombat, pNormal)
 		else
 			local tUnits = MultiBot.frames["MultiBar"].frames["Units"]
 			for key, value in pairs(MultiBot.index.actives) do
-				if(tUnits.buttons[value].name ~= UnitName("player")) then
+				if(tUnits.buttons[value] and tUnits.buttons[value].name ~= UnitName("player") and tUnits.frames[value]) then
 					tUnits.frames[value].getButton("Spellbook").setDisable()
 				end
 			end


### PR DESCRIPTION
Fixed a null error when opening. This was probably a conflict with some addon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when active units are missing their associated button or frame.
  * Prevented errors while checking or disabling Spellbook buttons in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->