### PR TITLE
Suppress automatic trade inventory whisper dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ still work when the player explicitly wants to inspect a bot state.
 The goal is not to remove useful manual commands.  
 The goal is to remove automatic UI-refresh spam.
 
+The remaining legacy Playerbots Trade inventory dump is also suppressed locally by the addon. The filter recognizes the exact `=== Inventory ===` dump from known bots and hides that automatic dump for Inventory -> Trade, Enchanting -> Trade and the native WoW client Trade action, while leaving the Trade workflow itself unchanged.
+
 ### Warlock weapon-enchant diagnostic
 
 For targeted runtime diagnostics, the addon exposes:
@@ -261,6 +263,10 @@ The endpoint and safe Firestone/Spellstone switching code are present, but the p
   <tr>
     <td>Enchanting Trade Service</td>
     <td><strong>Bridge-first and runtime validated</strong> — <code>ENCHANT_TRADE_V1</code> exposes known Enchanting services, reagent/tool availability and native Trade-slot execution without a generic cast/chat executor; the same dedicated window is available from the enchanter EveryBar and Character Info, with UI text localized in all eight runtime locales</td>
+  </tr>
+  <tr>
+    <td>Trade inventory chat suppression</td>
+    <td><strong>Runtime validated</strong> — the legacy Playerbots <code>=== Inventory ===</code> Trade-start dump is hidden for Inventory, Enchanting and native client Trade openings; the filter is limited to the exact dump sequence from known bots and does not modify Playerbots or the Bridge</td>
   </tr>
   <tr>
     <td>Glyphs</td>

--- a/UI/MultiBotEnchantingUI.lua
+++ b/UI/MultiBotEnchantingUI.lua
@@ -533,6 +533,9 @@ function EnchantUI:ApplySelected()
     end
 
     if TradeFrame and TradeFrame.IsShown and not TradeFrame:IsShown() and InitiateTrade then
+        if MultiBot.SuppressNextTradeInventoryDump then
+            MultiBot.SuppressNextTradeInventoryDump(self.botName)
+        end
         InitiateTrade(self.botName)
         frame.status:SetText(L("enchant.trade.status.trade_requested", "Trade requested. Put your item in the Will not be traded slot, then click Enchant again."))
         return false
@@ -581,6 +584,9 @@ function EnchantUI:Open(botName)
     setButtonEnabled(frame.refresh, true)
 
     if TradeFrame and TradeFrame.IsShown and not TradeFrame:IsShown() and InitiateTrade then
+        if MultiBot.SuppressNextTradeInventoryDump then
+            MultiBot.SuppressNextTradeInventoryDump(botName)
+        end
         InitiateTrade(botName)
     end
     self:RequestList()

--- a/UI/MultiBotInventoryFrame.lua
+++ b/UI/MultiBotInventoryFrame.lua
@@ -166,7 +166,11 @@ local function shouldSuppressTradeInventoryWhisper(message, author)
             return true
         end
 
-        if isKnownInventoryBotAuthor(author) then
+        if isKnownInventoryBotAuthor(author)
+            and TradeFrame
+            and TradeFrame.IsShown
+            and TradeFrame:IsShown()
+        then
             inventory.tradeInventoryDumpFilter = {
                 botKey = authorKey,
                 expiresAt = now + TRADE_INVENTORY_DUMP_FILTER_TTL,

--- a/UI/MultiBotInventoryFrame.lua
+++ b/UI/MultiBotInventoryFrame.lua
@@ -76,8 +76,44 @@ local function isTradeInventoryDumpStart(message)
         return false
     end
 
-    return string.find(message, "Inventory", 1, true) ~= nil
-        or string.find(message, "背包", 1, true) ~= nil
+    return message == "=== Inventory ==="
+        or message == "=== 背包 ==="
+end
+
+local function isKnownInventoryBotAuthor(author)
+    local authorKey = normalizeInventoryAuthorName(author)
+    if authorKey == "" then
+        return false
+    end
+
+    local playerName = UnitName and UnitName("player") or nil
+    if playerName and normalizeInventoryAuthorName(playerName) == authorKey then
+        return false
+    end
+
+    local actives = MultiBot and MultiBot.index and MultiBot.index.actives or nil
+    if type(actives) == "table" then
+        for _, botName in pairs(actives) do
+            if normalizeInventoryAuthorName(botName) == authorKey then
+                return true
+            end
+        end
+    end
+
+    local units = MultiBot
+        and MultiBot.frames
+        and MultiBot.frames["MultiBar"]
+        and MultiBot.frames["MultiBar"].frames
+        and MultiBot.frames["MultiBar"].frames["Units"]
+    if units and type(units.frames) == "table" then
+        for botName in pairs(units.frames) do
+            if normalizeInventoryAuthorName(botName) == authorKey then
+                return true
+            end
+        end
+    end
+
+    return false
 end
 
 local function isTradeInventoryDumpEnd(message)
@@ -111,24 +147,40 @@ end
 
 local function shouldSuppressTradeInventoryWhisper(message, author)
     local inventory = MultiBot and MultiBot.inventory or nil
-    local state = inventory and inventory.tradeInventoryDumpFilter or nil
-    if type(state) ~= "table" then
+    if not inventory then
         return false
     end
 
     local now = inventoryFrameNow()
-    if state.expiresAt and now > state.expiresAt then
-        inventory.tradeInventoryDumpFilter = nil
-        return false
-    end
+    local authorKey = normalizeInventoryAuthorName(author)
+    local state = inventory.tradeInventoryDumpFilter
 
-    if normalizeInventoryAuthorName(author) ~= state.botKey then
-        return false
+    if type(state) == "table" and state.expiresAt and now > state.expiresAt then
+        inventory.tradeInventoryDumpFilter = nil
+        state = nil
     end
 
     if isTradeInventoryDumpStart(message) then
-        state.active = true
-        return true
+        if type(state) == "table" and authorKey == state.botKey then
+            state.active = true
+            return true
+        end
+
+        if isKnownInventoryBotAuthor(author) then
+            inventory.tradeInventoryDumpFilter = {
+                botKey = authorKey,
+                expiresAt = now + TRADE_INVENTORY_DUMP_FILTER_TTL,
+                active = true,
+                autoDetected = true,
+            }
+            return true
+        end
+
+        return false
+    end
+
+    if type(state) ~= "table" or authorKey ~= state.botKey then
+        return false
     end
 
     if not state.active then
@@ -192,6 +244,8 @@ local function suppressNextTradeInventoryDump(botName)
         active = false,
     }
 end
+
+MultiBot.SuppressNextTradeInventoryDump = suppressNextTradeInventoryDump
 
 local function clearTradeInventoryDumpFilter()
     if MultiBot.inventory then
@@ -1362,6 +1416,7 @@ function MultiBot.InitializeInventoryFrame()
     }
 
     MultiBot.inventory = inventory
+    ensureTradeInventoryDumpFilter()
 
     content.actionHost.inventoryRef = inventory
     for _, button in pairs(content.buttons) do

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,23 +1,23 @@
 # Multibot Chatless + Bridge — Roadmap de reprise
 
 Statut : roadmap active issue de l'audit initial v1c du 1er août 2026, resynchronisée avec l'état post-merge du 14 août 2026.
-Dernière mise à jour : 14/08/2026 — service d'enchantement d'objet `ENCHANT_TRADE_V1` implémenté et validé en jeu, UI 440 px/i18n validées ; prochain chantier normal fixé à l'ajout/retrait d'items précis dans les règles de loot.
+Dernière mise à jour : 15/08/2026 — `ENCHANT_TRADE_V1` est mergé (Addon #63 / Bridge #27) et la suppression locale du dump inventaire automatique à l'ouverture d'un Trade est validée sans régression ; prochain chantier normal inchangé : ajout/retrait d'items précis dans les règles de loot.
 Cette roadmap est la source de vérité active du projet. Les anciens trackers et le fichier `TODO.md` ont été consolidés ici.
 
 ## Baseline auditée
 
-Audit de synchronisation : `audit-multibot-roadmap-next-item-v1-2026-08-14-143927`.
+Audit de synchronisation : `audit-multibot-trade-inventory-whisper-spam-v1b-2026-08-15-004941`, complété par les patches runtime validés de suppression du dump Trade.
 
 - Addon : `L:\ChromieCraft_3.3.5a\Interface\AddOns\MultiBot`
   - branche `main` ;
-  - HEAD et `origin/main` : `106074c3c93f80812f73af27e746860c7c8a4dcf` ;
-  - merge PR #61 : **Add chatless group Roll UI** ;
-  - worktree propre au début et à la fin de l'audit.
+  - HEAD et `origin/main` avant le correctif Trade local : `2c827f0acf305030d9d97ed797f9c798a25daab3` ;
+  - merge PR #63 : **Add chatless Enchanting Trade Service UI** ;
+  - correctif local validé en jeu : suppression du dump inventaire automatique lors des ouvertures Trade Inventory, Enchanting et client WoW natif.
 - Bridge : `L:\AC_PB\azerothcore-wotlk\modules\mod-multibot-bridge`
   - branche `main` ;
-  - HEAD et `origin/main` : `210bd1f4f6597fe4f0691ec729ec4904ebe2d463` ;
-  - merge PR #26 : **Add chatless group Roll support** ;
-  - worktree propre au début et à la fin de l'audit.
+  - HEAD et `origin/main` : `112428373dbd5741b55028e3efca299480a769bb` ;
+  - merge PR #27 : **Add ENCHANT_TRADE_V1 native enchanting trade service** ;
+  - aucun changement requis pour le correctif de spam Trade.
 - Playerbots : `L:\AC_PB\azerothcore-wotlk\modules\mod-playerbots`
   - branche `master`, commit `a7b885d27134466dbc1c91d39b8241ea725a1bbb` ;
   - **lecture seule stricte** ; invariant avant/après audit : `OK`.
@@ -328,10 +328,11 @@ Ordre recommandé et état réel :
 6. **`s vendor` / `SELL_VENDOR` : TERMINÉ pour le chemin bridge-first inventaire** — `INVENTORY_BULK_SELL_V1`, validation serveur et résultat structuré ; fallback legacy de compatibilité conservé si la capacité n'est pas disponible.
 7. **`open items` / `OPEN_ITEMS` : TERMINÉ / VALIDÉ / MERGÉ** — `INVENTORY_OPEN_V1`, Addon PR #60, Bridge PR #25.
 8. **`roll` et `roll [item]` : TERMINÉ / VALIDÉ / MERGÉ** — `GROUP_ROLL_V1`, Addon PR #61, Bridge PR #26.
-9. **Enchantement d'objet : TERMINÉ / VALIDÉ EN JEU — PR EN COURS (Addon #63 / Bridge #27)** — `ENCHANT_TRADE_V1`, UI dédiée aux enchanteurs, liste des enchantements réellement connus, composants/outils, Trade WoW natif via le slot « ne sera pas échangé », exécution par ID de sort numérique validé côté bridge, sans exécuteur générique de cast/chat ; layout 440 px et i18n des 8 locales validés.
-10. **PROCHAIN CHANTIER NORMAL — Ajout/retrait d'items précis dans les règles de loot.**
-11. **À FAIRE — Décision sur `Quest`/`Skill` versus `Disenchant`**, sans inventer de stratégie absente de Playerbots.
-12. **À FAIRE — Ordres collectifs `follow`, `attack`, `stay`**, seulement après validation manuelle exacte des sélecteurs Playerbots ; ne pas réintroduire `RUN~ORDER` générique.
+9. **Enchantement d'objet : TERMINÉ / VALIDÉ EN JEU / MERGÉ — Addon #63 / Bridge #27** — `ENCHANT_TRADE_V1`, UI dédiée aux enchanteurs, liste des enchantements réellement connus, composants/outils, Trade WoW natif via le slot « ne sera pas échangé », exécution par ID de sort numérique validé côté bridge, sans exécuteur générique de cast/chat ; layout 440 px et i18n des 8 locales validés.
+10. **Spam inventaire automatique à l'ouverture Trade : TERMINÉ / VALIDÉ EN JEU — PR ADDON À OUVRIR** — réutilisation puis généralisation du filtre addon existant : détection du header exact `=== Inventory ===` pour un bot connu, suppression du dump lors des chemins Inventory → Trade, Enchanting → Trade et du menu natif WoW « Échanger », sans modification de Playerbots ni du Bridge.
+11. **PROCHAIN CHANTIER NORMAL — Ajout/retrait d'items précis dans les règles de loot.**
+12. **À FAIRE — Décision sur `Quest`/`Skill` versus `Disenchant`**, sans inventer de stratégie absente de Playerbots.
+13. **À FAIRE — Ordres collectifs `follow`, `attack`, `stay`**, seulement après validation manuelle exacte des sélecteurs Playerbots ; ne pas réintroduire `RUN~ORDER` générique.
 
 Les commandes informatives `who`, `co ?`, `nc ?` et `ss ?` restent manuelles tant qu'aucune UI structurée ne les remplace. Les mutations UI automatiques `co/nc`, en revanche, doivent passer par le bridge dès qu'un contrat structuré validé existe.
 
@@ -346,7 +347,20 @@ Les commandes informatives `who`, `co ?`, `nc ?` et `ss ?` restent manuelles tan
 - UI dédiée visible uniquement pour les bots enchanteurs, accessible depuis l'EveryBar et Character Info ;
 - fenêtre réduite à 440 px, champ de recherche corrigé et textes Enchant Trade localisés dans les 8 locales runtime ;
 - test en jeu : ouverture, liste, recherche, tooltips, Trade et enchantement réel **OK** ;
-- spam chat automatique lié à ce service : **aucun**.
+- spam chat automatique lié au service Enchanting : **aucun après correctif Trade validé le 15/08/2026** ;
+- l'ouverture du Trade par l'UI Enchanting réutilise le filtre de dump inventaire déjà employé par Inventory → Trade.
+
+### Validation suppression du dump Inventory à l'ouverture Trade — 15/08/2026
+
+- cause auditée dans Playerbots en lecture seule : `TradeStatusAction::BeginTrade()` envoie automatiquement `=== Inventory ===` puis le contenu de l'inventaire au maître lors du démarrage d'un échange ;
+- `mod-playerbots` reste strictement inchangé ;
+- le filtre addon existant du bouton Inventory → Trade a d'abord été exporté puis réutilisé par les deux appels `InitiateTrade()` de l'UI Enchanting ;
+- le filtre a ensuite été généralisé côté addon pour reconnaître automatiquement le header exact `=== Inventory ===` provenant d'un bot connu, ce qui couvre aussi le menu contextuel natif WoW « Échanger » ;
+- le matching large sur le simple mot `Inventory` a été retiré afin d'éviter de masquer un whisper normal ;
+- tests en jeu : Inventory → Trade silencieux, Enchanting → Trade silencieux, menu natif WoW « Échanger » silencieux ;
+- enchantement réel et workflow Trade conservés ;
+- aucune régression observée par l'utilisateur ;
+- Bridge inchangé, Playerbots inchangé, aucun rebuild worldserver requis.
 
 ### Chantiers suspendus — à reprendre seulement après la roadmap normale
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -329,7 +329,7 @@ Ordre recommandé et état réel :
 7. **`open items` / `OPEN_ITEMS` : TERMINÉ / VALIDÉ / MERGÉ** — `INVENTORY_OPEN_V1`, Addon PR #60, Bridge PR #25.
 8. **`roll` et `roll [item]` : TERMINÉ / VALIDÉ / MERGÉ** — `GROUP_ROLL_V1`, Addon PR #61, Bridge PR #26.
 9. **Enchantement d'objet : TERMINÉ / VALIDÉ EN JEU / MERGÉ — Addon #63 / Bridge #27** — `ENCHANT_TRADE_V1`, UI dédiée aux enchanteurs, liste des enchantements réellement connus, composants/outils, Trade WoW natif via le slot « ne sera pas échangé », exécution par ID de sort numérique validé côté bridge, sans exécuteur générique de cast/chat ; layout 440 px et i18n des 8 locales validés.
-10. **Spam inventaire automatique à l'ouverture Trade : TERMINÉ / VALIDÉ EN JEU — PR ADDON À OUVRIR** — réutilisation puis généralisation du filtre addon existant : détection du header exact `=== Inventory ===` pour un bot connu, suppression du dump lors des chemins Inventory → Trade, Enchanting → Trade et du menu natif WoW « Échanger », sans modification de Playerbots ni du Bridge.
+10. **Spam inventaire automatique à l'ouverture Trade : TERMINÉ / VALIDÉ EN JEU — PR ADDON #64 EN COURS** — réutilisation puis généralisation du filtre addon existant : détection du header exact `=== Inventory ===` pour un bot connu, suppression du dump lors des chemins Inventory → Trade, Enchanting → Trade et du menu natif WoW « Échanger », sans modification de Playerbots ni du Bridge.
 11. **PROCHAIN CHANTIER NORMAL — Ajout/retrait d'items précis dans les règles de loot.**
 12. **À FAIRE — Décision sur `Quest`/`Skill` versus `Disenchant`**, sans inventer de stratégie absente de Playerbots.
 13. **À FAIRE — Ordres collectifs `follow`, `attack`, `stay`**, seulement après validation manuelle exacte des sélecteurs Playerbots ; ne pas réintroduire `RUN~ORDER` générique.
@@ -355,7 +355,7 @@ Les commandes informatives `who`, `co ?`, `nc ?` et `ss ?` restent manuelles tan
 - cause auditée dans Playerbots en lecture seule : `TradeStatusAction::BeginTrade()` envoie automatiquement `=== Inventory ===` puis le contenu de l'inventaire au maître lors du démarrage d'un échange ;
 - `mod-playerbots` reste strictement inchangé ;
 - le filtre addon existant du bouton Inventory → Trade a d'abord été exporté puis réutilisé par les deux appels `InitiateTrade()` de l'UI Enchanting ;
-- le filtre a ensuite été généralisé côté addon pour reconnaître automatiquement le header exact `=== Inventory ===` provenant d'un bot connu, ce qui couvre aussi le menu contextuel natif WoW « Échanger » ;
+- le filtre a ensuite été généralisé côté addon pour reconnaître automatiquement le header exact `=== Inventory ===` provenant d'un bot connu uniquement lorsqu'une fenêtre Trade est ouverte, ce qui couvre aussi le menu contextuel natif WoW « Échanger » sans masquer la sortie manuelle `item count` hors Trade ;
 - le matching large sur le simple mot `Inventory` a été retiré afin d'éviter de masquer un whisper normal ;
 - tests en jeu : Inventory → Trade silencieux, Enchanting → Trade silencieux, menu natif WoW « Échanger » silencieux ;
 - enchantement réel et workflow Trade conservés ;


### PR DESCRIPTION
## Summary

Suppresses the legacy Playerbots inventory dump that is automatically whispered to the player when a Trade window opens.

The existing suppression already used by the Inventory -> Trade workflow is now reused by the Enchanting Trade Service and extended to native WoW client Trade openings such as right-clicking a bot and selecting Trade.

## Changes

- exports and reuses the existing Trade inventory-dump suppression helper;
- arms the suppression before both Enchanting `InitiateTrade()` paths;
- initializes the whisper display filter when the Inventory module loads;
- automatically detects the exact Playerbots dump header: `=== Inventory ===`
- limits automatic detection to known MultiBot bots;
- removes the previous broad match based only on the word `Inventory`;
- preserves the existing Inventory -> Trade behavior;
- updates `README.md` and `docs/ROADMAP.md`;
- records Addon #63 / Bridge #27 Enchant Trade as merged;
- records Trade inventory-spam suppression as runtime validated.

## Safety

- addon-only change;
- no `mod-multibot-bridge` source change;
- no `mod-playerbots` change;
- Playerbots remained strictly read-only;
- no generic whisper/chat suppression;
- normal bot whispers remain available;
- the native WoW Trade workflow is unchanged;
- `ENCHANT_TRADE_V1` protocol and server-side validation are unchanged.

## Runtime validation

Validated in game on WoW 3.3.5a:

- Inventory -> Trade: no inventory whisper dump;
- Enchanting -> Trade: no inventory whisper dump;
- native WoW right-click bot -> Trade: no inventory whisper dump;
- Trade window still opens and works normally;
- real Enchanting/Trade workflow remains functional;
- no regression observed;
- no new automatic chat spam observed.

## Verification

- `README_SYNC=OK`
- `ROADMAP_SYNC=OK`
- `ENCHANT_PRS_MARKED_MERGED=OK`
- `TRADE_SPAM_MARKED_RUNTIME_VALIDATED=OK`
- `NEXT_ROADMAP_ITEM_UNCHANGED=OK`
- `UI_HASHES=OK`
- `GIT_SCOPE=OK`
- `DIFF_CHECK=OK`
- `BRIDGE_UNCHANGED=OK`
- `PLAYERBOTS_READ_ONLY_INVARIANT=OK`
- `FINAL_STATUS=OK`

No CMake rerun or worldserver rebuild is required.

## Files changed

- `README.md`
- `UI/MultiBotEnchantingUI.lua`
- `UI/MultiBotInventoryFrame.lua`
- `docs/ROADMAP.md`

## Roadmap

The next normal roadmap item remains:

**Item-specific add/remove support for loot rules.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unwanted legacy inventory-dump messages when opening Inventory, Enchanting, or native WoW Trade windows.
  * Improved filtering to recognize supported English and Chinese dump formats only from known bots.
  * Added temporary suppression handling to prevent relevant dump messages from appearing during trades.

* **Documentation**
  * Updated feature documentation and roadmap entries to reflect the validated inventory-dump suppression behavior and completed milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->